### PR TITLE
Rename Cheat Menu header

### DIFF
--- a/7d2dMonoInternal/UI/NewMenu.cs
+++ b/7d2dMonoInternal/UI/NewMenu.cs
@@ -161,7 +161,7 @@ namespace SevenDTDMono
 
             if (drawMenu)
             {
-                windowRect = GUILayout.Window(windowID, windowRect, Window, "7Days To Die Cheat Menu",customStyle); //draws main menu
+                windowRect = GUILayout.Window(windowID, windowRect, Window, "7Days To Die Mod Menü",customStyle); //draws main menu
             }
             // Create a new GUIStyle based on the default GUI.skin.box
             // Set the desired background color for the box


### PR DESCRIPTION
## Summary
- rename window title from "7Days To Die Cheat Menu" to "7Days To Die Mod Menü"

## Testing
- `dotnet build 7DTD-Main.sln` *(fails: .NET Framework 4.8 reference assemblies missing)*

------
https://chatgpt.com/codex/tasks/task_e_68781e9a5bd483309b3604db679cf3fa