### PR TITLE
Fix hardcoded build paths

### DIFF
--- a/7d2dMonoInternal/Directory.Build.props
+++ b/7d2dMonoInternal/Directory.Build.props
@@ -19,8 +19,8 @@
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <Prefer32Bit>false</Prefer32Bit>
     <Optimize>false</Optimize>
-    <OutputPath>T:\Temp\vsBuild\SingelBuild\$(SolutionName)\$(Platform)\$(Configuration)\</OutputPath>
-    <IntermediateOutputPath>T:\Temp\vsBuild\SingelBuild\$(SolutionName)\$(Platform)\$(Configuration)\Intermediate\$(MSBuildProjectName)\</IntermediateOutputPath>
+    <OutputPath>$(MSBuildThisFileDirectory)build\$(SolutionName)\$(Platform)\$(Configuration)\</OutputPath>
+    <IntermediateOutputPath>$(MSBuildThisFileDirectory)build\$(SolutionName)\$(Platform)\$(Configuration)\Intermediate\$(MSBuildProjectName)\</IntermediateOutputPath>
   </PropertyGroup>
 
 
@@ -33,8 +33,8 @@
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <Prefer32Bit>false</Prefer32Bit>
     <Optimize>false</Optimize>
-    <OutputPath>T:\Temp\vsBuild\SingelBuild\$(SolutionName)\$(Platform)\$(Configuration)\</OutputPath>
-    <IntermediateOutputPath>T:\Temp\vsBuild\SingelBuild\$(SolutionName)\$(Platform)\$(Configuration)\Intermediate\$(MSBuildProjectName)\</IntermediateOutputPath>
+    <OutputPath>$(MSBuildThisFileDirectory)build\$(SolutionName)\$(Platform)\$(Configuration)\</OutputPath>
+    <IntermediateOutputPath>$(MSBuildThisFileDirectory)build\$(SolutionName)\$(Platform)\$(Configuration)\Intermediate\$(MSBuildProjectName)\</IntermediateOutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release_NOUE|AnyCPU' ">
@@ -45,8 +45,8 @@
     <DefineConstants>RELEASE_NOUE</DefineConstants>
     <Prefer32Bit>false</Prefer32Bit>
     <Optimize>false</Optimize>
-    <OutputPath>T:\Temp\vsBuild\SingelBuild\$(SolutionName)\$(Platform)\$(Configuration)\</OutputPath>
-    <IntermediateOutputPath>T:\Temp\vsBuild\SingelBuild\$(SolutionName)\$(Platform)\$(Configuration)\Intermediate\$(MSBuildProjectName)\</IntermediateOutputPath>
+    <OutputPath>$(MSBuildThisFileDirectory)build\$(SolutionName)\$(Platform)\$(Configuration)\</OutputPath>
+    <IntermediateOutputPath>$(MSBuildThisFileDirectory)build\$(SolutionName)\$(Platform)\$(Configuration)\Intermediate\$(MSBuildProjectName)\</IntermediateOutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release_UE|AnyCPU' ">
@@ -57,8 +57,8 @@
     <DefineConstants>RELEASE_UE</DefineConstants>
     <Prefer32Bit>false</Prefer32Bit>
     <Optimize>false</Optimize>
-    <OutputPath>T:\Temp\vsBuild\SingelBuild\$(SolutionName)\$(Platform)\$(Configuration)\</OutputPath>
-    <IntermediateOutputPath>T:\Temp\vsBuild\SingelBuild\$(SolutionName)\$(Platform)\$(Configuration)\Intermediate\$(MSBuildProjectName)\</IntermediateOutputPath>
+    <OutputPath>$(MSBuildThisFileDirectory)build\$(SolutionName)\$(Platform)\$(Configuration)\</OutputPath>
+    <IntermediateOutputPath>$(MSBuildThisFileDirectory)build\$(SolutionName)\$(Platform)\$(Configuration)\Intermediate\$(MSBuildProjectName)\</IntermediateOutputPath>
   </PropertyGroup>
 
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,8 +5,8 @@
 		<TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
 		<WarningLevel>4</WarningLevel>
 		<ErrorReport>prompt</ErrorReport>
-		<IntermediateOutputPath>T:\Temp\vsBuild\SingelBuild\$(SolutionName)\$(Platform)\$(Configuration)\Intermediate\$(MSBuildProjectName)\</IntermediateOutputPath>
-		<OutputPath>T:\Temp\vsBuild\SingelBuild\$(SolutionName)\$(Platform)\$(Configuration)\</OutputPath>
+                <IntermediateOutputPath>$(MSBuildThisFileDirectory)build\$(SolutionName)\$(Platform)\$(Configuration)\Intermediate\$(MSBuildProjectName)\</IntermediateOutputPath>
+                <OutputPath>$(MSBuildThisFileDirectory)build\$(SolutionName)\$(Platform)\$(Configuration)\</OutputPath>
 
 	</PropertyGroup>
 


### PR DESCRIPTION
## Summary
- build artifacts in repo-relative folder instead of T drive

## Testing
- `dotnet build 7DTD-Main.sln -c Debug -v minimal` *(fails: reference assemblies for .NET Framework 4.8 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6878371ec6c08330bca899bc5ed44981