### PR TITLE
Fix compile errors

### DIFF
--- a/7d2dMonoInternal/Features/Cheat.cs
+++ b/7d2dMonoInternal/Features/Cheat.cs
@@ -435,14 +435,7 @@ namespace SevenDTDMono.Features
                                  Values = new float[] { 9999 },
                                  //Set other properties if needed
                             }
-                    },
-                    PassivesIndex = new List<PassiveEffects>
-                        {
-                             PassiveEffects.WalkSpeed,
-                             PassiveEffects.BlockDamage,
-                             PassiveEffects.CraftingTime,
-                             PassiveEffects.FoodGain,
-                        }
+                    }
                 }
 
             };
@@ -517,14 +510,6 @@ namespace SevenDTDMono.Features
                                  Values = new float[] { 9999 },
                                  //Set other properties if needed
                             }
-                        },
-     
-                        PassivesIndex = new List<PassiveEffects>
-                        {
-                             PassiveEffects.WalkSpeed,
-                             PassiveEffects.BlockDamage,
-                             PassiveEffects.CraftingTime,
-                             PassiveEffects.FoodGain,
                         }
 
                     }
@@ -584,10 +569,7 @@ namespace SevenDTDMono.Features
                    OwnerTiered = true,
                    PassiveEffects = new List<PassiveEffect>
                    {
-                   },
-                   PassivesIndex = new List<PassiveEffects>
-                       {
-                       }
+                   }
                }
             };
             //O._minEffectController.PassivesIndex = new HashSet<PassiveEffects>();

--- a/7d2dMonoInternal/Features/CheatBuff.cs
+++ b/7d2dMonoInternal/Features/CheatBuff.cs
@@ -87,10 +87,6 @@ namespace SevenDTDMono.Features
                             Values = new float[] { 20}
                             //Set other properties of PassiveEffect if needed
                         }
-                    },
-                    PassivesIndex = new List<PassiveEffects>
-                    {
-                        PassiveEffects.None,
                     }
                 }
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
-New repository for remaking the 7DTD (7 days to die) legit mod. 
+New repository for remaking the 7DTD (7 days to die) legit mod.
 It is made for educational purposes only and cannot be used in multiplayer.
+
+## Build
+To compile without optional UnityExplorer support use the `Release` configuration:
+
+```
+dotnet build -c Release
+```
+
+The `DEBUG` and `RELEASE_UE` configurations require the `UnityExplorer.STANDALONE.Mono.dll`
+library to be present in the path referenced by `SevenDTDMono.csproj`.


### PR DESCRIPTION
## Summary
- remove use of `MinEffectGroup.PassivesIndex` as the class doesn't expose it
- document how to build without UnityExplorer

## Testing
- `dotnet build 7DTD-Main.sln -c Release` *(fails: reference assemblies for .NET Framework 4.8 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68783b9f8bd88330abe98d44ec32d284