### PR TITLE
Fix aimbot rotation

### DIFF
--- a/7d2dMonoInternal/Features/Aimbot/Aimbot.cs
+++ b/7d2dMonoInternal/Features/Aimbot/Aimbot.cs
@@ -47,7 +47,17 @@ namespace SevenDTDMono.Features
                 Vector3 head = bestZombie.emodel.GetHeadTransform().position;
                 Vector3 direction = head - playerHead;
                 Quaternion look = Quaternion.LookRotation(direction);
-                Player.transform.rotation = Quaternion.Slerp(Player.transform.rotation, look, Time.deltaTime * 15f);
+
+                // Instantly rotate the player towards the target to ensure that
+                // fired projectiles follow the corrected view direction.
+                Player.transform.rotation = look;
+
+                // Align the main camera as well if it exists so the crosshair
+                // matches the updated orientation.
+                if (Camera.main)
+                {
+                    Camera.main.transform.rotation = look;
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- fix aimbot rotation so shots align with the target

## Testing
- `dotnet build 7DTD-Main.sln -c Release` *(fails: reference assemblies for .NET Framework 4.8 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68784ff721708330bfb655218f9e91f1