### PR TITLE
Add dropdown for aimbot target

### DIFF
--- a/7d2dMonoInternal/Features/Aimbot/Aimbot.cs
+++ b/7d2dMonoInternal/Features/Aimbot/Aimbot.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using System.Collections.Generic;
+using SevenDTDMono;
 
 namespace SevenDTDMono.Features
 {
@@ -57,8 +58,19 @@ namespace SevenDTDMono.Features
 
             if (bestZombie != null)
             {
-                Vector3 head = bestZombie.emodel.GetHeadTransform().position;
-                Vector3 direction = head - playerHead;
+                Vector3 targetPos = bestZombie.emodel.GetHeadTransform().position;
+
+                switch (SettingsInstance.SelectedAimbotTarget)
+                {
+                    case AimbotTarget.Chest:
+                        targetPos = bestZombie.transform.position + Vector3.up * 1.0f;
+                        break;
+                    case AimbotTarget.Leg:
+                        targetPos = bestZombie.transform.position + Vector3.up * 0.3f;
+                        break;
+                }
+
+                Vector3 direction = targetPos - playerHead;
                 Quaternion look = Quaternion.LookRotation(direction);
 
                 // Smoothly rotate the player towards the target. Directly

--- a/7d2dMonoInternal/Misc/EnumAimbotTarget.cs
+++ b/7d2dMonoInternal/Misc/EnumAimbotTarget.cs
@@ -1,0 +1,9 @@
+namespace SevenDTDMono
+{
+    public enum AimbotTarget
+    {
+        Head,
+        Chest,
+        Leg
+    }
+}

--- a/7d2dMonoInternal/NewSettings.cs
+++ b/7d2dMonoInternal/NewSettings.cs
@@ -46,6 +46,9 @@ namespace SevenDTDMono
         public static float FloatHarvestCountMultiplier = 0.5f;//Harvest count
         public static float FloatAttacksPerMinuteMultiplier = 0.5f;//Attacks Per Minute
 
+        // Selected target area for the aimbot feature
+        public AimbotTarget SelectedAimbotTarget = AimbotTarget.Head;
+
 
         #endregion //define
 

--- a/7d2dMonoInternal/SevenDTDMono.csproj
+++ b/7d2dMonoInternal/SevenDTDMono.csproj
@@ -335,6 +335,7 @@
     <Compile Include="GuiLayoutExtended\GUIUnsorted.cs" />
     <Compile Include="Misc\EnumChildDictionaries.cs" />
     <Compile Include="Misc\EnumNonDynamicLoadBools.cs" />
+    <Compile Include="Misc\EnumAimbotTarget.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Utils\AssemblyHelper.cs" />
     <Compile Include="GuiLayoutExtended\GUILayoutExtensions.cs" />

--- a/7d2dMonoInternal/UI/NewMenu.cs
+++ b/7d2dMonoInternal/UI/NewMenu.cs
@@ -35,6 +35,7 @@ namespace SevenDTDMono
         private string inputValuModType = string.Empty;
         private int currentIndex = 0;
         private int ValueModifierTypesIndex = 0;
+        private bool aimbotSettingsDropdown = false;
 
         #endregion
 
@@ -671,6 +672,20 @@ namespace SevenDTDMono
                     }
 
                     NewGUILayout.ButtonToggleDictionary("Aimbot", nameof(SettingsBools.AIMBOT));
+
+                    if (_boolDict[nameof(SettingsBools.AIMBOT)])
+                    {
+                        NewGUILayout.DropDownForMethods("Aimbot Target", () =>
+                        {
+                            string[] targets = System.Enum.GetNames(typeof(AimbotTarget));
+                            int selected = (int)SettingsInstance.SelectedAimbotTarget;
+                            int newSelected = GUILayout.Toolbar(selected, targets);
+                            if (newSelected != selected)
+                            {
+                                SettingsInstance.SelectedAimbotTarget = (AimbotTarget)newSelected;
+                            }
+                        }, ref aimbotSettingsDropdown);
+                    }
 
                 });
 


### PR DESCRIPTION
## Summary
- support choosing aimbot target (head/chest/leg)
- store selected part in `NewSettings`
- implement dropdown in the UI shown when aimbot is enabled
- update aimbot logic to use selected target
- include new enum in project file

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6878554967bc833096601b5102eaa285