### PR TITLE
Add Magic Bullet toggle

### DIFF
--- a/7d2dMonoInternal/Features/Magic/MagicBullet.cs
+++ b/7d2dMonoInternal/Features/Magic/MagicBullet.cs
@@ -1,0 +1,75 @@
+using UnityEngine;
+using System.Collections.Generic;
+
+namespace SevenDTDMono.Features.Magic
+{
+    public class MagicBullet : MonoBehaviour
+    {
+        private static NewSettings SettingsInstance => NewSettings.Instance;
+        private static Dictionary<string, bool> BoolDict => SettingsInstance.GetChildDictionary<bool>(nameof(Dictionaries.BOOL_DICTIONARY));
+        private static EntityPlayerLocal Player => NewSettings.EntityLocalPlayer;
+
+        private readonly KeyCode activationKey = KeyCode.LeftAlt;
+
+        private void Update()
+        {
+            if (!SettingsInstance.GetBoolValue(nameof(SettingsBools.MAGIC_BULLET)))
+            {
+                return;
+            }
+
+            if (!Input.GetKey(activationKey))
+            {
+                return;
+            }
+
+            if (Player == null || !NewSettings.GameManager.gameStateManager.bGameStarted)
+            {
+                return;
+            }
+
+            EntityAlive bestTarget = null;
+            float minAngle = float.MaxValue;
+            Vector3 playerHead = Player.emodel.GetHeadTransform().position;
+
+            foreach (EntityAlive entity in NewSettings.EntityAlive)
+            {
+                if (entity == null || !entity.IsAlive() || entity == Player)
+                {
+                    continue;
+                }
+
+                Vector3 head = entity.emodel.GetHeadTransform().position;
+                Vector3 direction = head - playerHead;
+                float angle = Vector3.Angle(Player.transform.forward, direction);
+                if (angle < minAngle)
+                {
+                    minAngle = angle;
+                    bestTarget = entity;
+                }
+            }
+
+            foreach (EntityPlayer player in NewSettings.EntityPlayers)
+            {
+                if (player == null || !player.IsAlive() || player == Player)
+                {
+                    continue;
+                }
+
+                Vector3 head = player.emodel.GetHeadTransform().position;
+                Vector3 direction = head - playerHead;
+                float angle = Vector3.Angle(Player.transform.forward, direction);
+                if (angle < minAngle)
+                {
+                    minAngle = angle;
+                    bestTarget = player;
+                }
+            }
+
+            if (bestTarget != null)
+            {
+                bestTarget.DamageEntity(new DamageSource(EnumDamageSource.Internal, EnumDamageTypes.Bullet), 99999, false, 1f);
+            }
+        }
+    }
+}

--- a/7d2dMonoInternal/Loader.cs
+++ b/7d2dMonoInternal/Loader.cs
@@ -38,6 +38,7 @@ namespace SevenDTDMono
             gameObject.AddComponent<Features.Render.Render>();
             gameObject.AddComponent<Features.Render.Visuals>();
             gameObject.AddComponent<Features.Aimbot>();
+            gameObject.AddComponent<Features.Magic.MagicBullet>();
 
             //gameObject.AddComponent<SceneDebugger>();
             //gameObject.AddComponent<CBuffs>();

--- a/7d2dMonoInternal/Misc/EnumNonDynamicLoadBools.cs
+++ b/7d2dMonoInternal/Misc/EnumNonDynamicLoadBools.cs
@@ -27,6 +27,7 @@ namespace SevenDTDMono
         BUFF_CLASSES_LOADED,
         PROGRESSION_VALUE_LOADED,
         NAME_SCRAMBLE,
-        AIMBOT
+        AIMBOT,
+        MAGIC_BULLET
     }
 }

--- a/7d2dMonoInternal/SevenDTDMono.csproj
+++ b/7d2dMonoInternal/SevenDTDMono.csproj
@@ -316,6 +316,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Features\Aimbot\Aimbot.cs" />
+    <Compile Include="Features\Magic\MagicBullet.cs" />
     <Compile Include="Features\Buffs\CBuffs.cs" />
     <Compile Include="Features\CheatBuff.cs" />
     <Compile Include="Features\Cheat.cs" />

--- a/7d2dMonoInternal/UI/NewMenu.cs
+++ b/7d2dMonoInternal/UI/NewMenu.cs
@@ -675,8 +675,9 @@ namespace SevenDTDMono
 
                     if (_boolDict[nameof(SettingsBools.AIMBOT)])
                     {
-                        NewGUILayout.DropDownForMethods("Aimbot Target", () =>
+                        NewGUILayout.DropDownForMethods("Aimbot Settings", () =>
                         {
+                            NewGUILayout.ButtonToggleDictionary("Magic Bullet", nameof(SettingsBools.MAGIC_BULLET));
                             string[] targets = System.Enum.GetNames(typeof(AimbotTarget));
                             int selected = (int)SettingsInstance.SelectedAimbotTarget;
                             int newSelected = GUILayout.Toolbar(selected, targets);


### PR DESCRIPTION
## Summary
- implement `MagicBullet` component to kill closest target while holding **LeftAlt**
- add `MAGIC_BULLET` enum and toggle in UI under Aimbot settings
- include new feature in loader and project file

## Testing
- `dotnet build 7DTD-Main.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878589687c883308b6e6d891f5527dd