### PR TITLE
Add FOV settings for aimbot

### DIFF
--- a/7d2dMonoInternal/Features/Aimbot/Aimbot.cs
+++ b/7d2dMonoInternal/Features/Aimbot/Aimbot.cs
@@ -38,6 +38,7 @@ namespace SevenDTDMono.Features
             EntityAlive bestZombie = null;
             float minAngle = float.MaxValue;
             Vector3 playerHead = Player.emodel.GetHeadTransform().position;
+            float maxAngle = SettingsInstance.AimbotFov * 0.5f;
 
             foreach (EntityAlive zombie in NewSettings.EntityAlive)
             {
@@ -49,6 +50,10 @@ namespace SevenDTDMono.Features
                 Vector3 head = zombie.emodel.GetHeadTransform().position;
                 Vector3 direction = head - playerHead;
                 float angle = Vector3.Angle(Player.transform.forward, direction);
+                if (angle > maxAngle)
+                {
+                    continue;
+                }
                 if (angle < minAngle)
                 {
                     minAngle = angle;

--- a/7d2dMonoInternal/Features/Render/Render.cs
+++ b/7d2dMonoInternal/Features/Render/Render.cs
@@ -72,11 +72,18 @@ namespace SevenDTDMono.Features.Render
             }
             if (SettingsInstance.GetBoolValue(nameof(SettingsBools.FOV_CIRCLE)))
             {
-                // Outline
-                RenderUtils.DrawCircle(Color.black, new Vector2(Screen.width / 2, Screen.height / 2), 149f);
-                RenderUtils.DrawCircle(Color.black, new Vector2(Screen.width / 2, Screen.height / 2), 151f);
+                float radius = 150f;
+                if (Camera.main)
+                {
+                    float angleRatio = Mathf.Tan(SettingsInstance.AimbotFov * Mathf.Deg2Rad * 0.5f) /
+                                       Mathf.Tan(Camera.main.fieldOfView * Mathf.Deg2Rad * 0.5f);
+                    radius = (Screen.height / 2f) * angleRatio;
+                }
 
-                RenderUtils.DrawCircle(new Color32(30, 144, 255, 255), new Vector2(Screen.width / 2, Screen.height / 2), 150f);
+                // Outline
+                RenderUtils.DrawCircle(Color.black, new Vector2(Screen.width / 2, Screen.height / 2), radius - 1f);
+                RenderUtils.DrawCircle(Color.black, new Vector2(Screen.width / 2, Screen.height / 2), radius + 1f);
+                RenderUtils.DrawCircle(new Color32(30, 144, 255, 255), new Vector2(Screen.width / 2, Screen.height / 2), radius);
             }
 
 

--- a/7d2dMonoInternal/NewSettings.cs
+++ b/7d2dMonoInternal/NewSettings.cs
@@ -49,6 +49,9 @@ namespace SevenDTDMono
         // Selected target area for the aimbot feature
         public AimbotTarget SelectedAimbotTarget = AimbotTarget.Head;
 
+        // Field of view in degrees used by the aimbot
+        public float AimbotFov = 60f;
+
 
         #endregion //define
 

--- a/7d2dMonoInternal/README.md
+++ b/7d2dMonoInternal/README.md
@@ -14,11 +14,11 @@ F7 default for UnityExplorer. rekomended to set to other button since 7dtd use f
 # Features
 1. Magic Bullet (players & zombies)
 2. Health ESP, Corner Box ESP, Name ESP, Box ESP, Chams (players & zombies)
-3. FOV Aimbot (players & zombies)
+3. FOV Aimbot with adjustable angle (players & zombies)
 4. No weapon sway, high viewmodel FOV
 5. Infinite ammo
 6. Toggle creative mode and debug mode +
-7. Crosshair, FOV circle
+7. Crosshair, toggleable FOV circle
 8. Speedhack
 9. Teleport to players / zombies Also Kill Players /Zombies
 10. Level up

--- a/7d2dMonoInternal/UI/NewMenu.cs
+++ b/7d2dMonoInternal/UI/NewMenu.cs
@@ -685,6 +685,12 @@ namespace SevenDTDMono
                             {
                                 SettingsInstance.SelectedAimbotTarget = (AimbotTarget)newSelected;
                             }
+
+                            GUILayout.BeginHorizontal();
+                            GUILayout.Label($"FOV {SettingsInstance.AimbotFov:F0}", GUILayout.MaxWidth(80));
+                            SettingsInstance.AimbotFov = GUILayout.HorizontalSlider(SettingsInstance.AimbotFov, 10f, 120f, GUILayout.Width(150));
+                            GUILayout.EndHorizontal();
+
                         }, ref aimbotSettingsDropdown);
                     }
 


### PR DESCRIPTION
## Summary
- add `AimbotFov` setting to `NewSettings`
- restrict aimbot targets to within the FOV
- render FOV circle using current FOV angle
- expose FOV slider under aimbot settings in the menu
- document feature in readme

## Testing
- `xbuild 7DTD-Main.sln /p:Configuration=Release` *(fails: 'OutputPath' property is not set)*

------
https://chatgpt.com/codex/tasks/task_e_6878599d2f04833090e84900ff3a930f