### PR TITLE
Fix magic bullet damage enumeration

### DIFF
--- a/7d2dMonoInternal/Features/Magic/MagicBullet.cs
+++ b/7d2dMonoInternal/Features/Magic/MagicBullet.cs
@@ -68,7 +68,9 @@ namespace SevenDTDMono.Features.Magic
 
             if (bestTarget != null)
             {
-                bestTarget.DamageEntity(new DamageSource(EnumDamageSource.Internal, EnumDamageTypes.Bullet), 99999, false, 1f);
+                // Use a generic damage type to ensure compatibility even if
+                // EnumDamageTypes.Bullet is unavailable in some game versions.
+                bestTarget.DamageEntity(new DamageSource(EnumDamageSource.Internal, EnumDamageTypes.Suicide), 99999, false, 1f);
             }
         }
     }


### PR DESCRIPTION
## Summary
- use an existing damage type for the magic bullet feature because the game API doesn't expose `Bullet`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68785b6216648330b3265527e060a55c