### PR TITLE
Add No Recoil toggle

### DIFF
--- a/7d2dMonoInternal/Features/Weapon/NoRecoil.cs
+++ b/7d2dMonoInternal/Features/Weapon/NoRecoil.cs
@@ -1,0 +1,44 @@
+using System.Reflection;
+using UnityEngine;
+
+namespace SevenDTDMono.Features.Weapon
+{
+    public class NoRecoil : MonoBehaviour
+    {
+        private static NewSettings SettingsInstance => NewSettings.Instance;
+        private static EntityPlayerLocal Player => NewSettings.EntityLocalPlayer;
+
+        private readonly string[] fieldNames =
+        {
+            "recoilYawMin", "recoilYawMax",
+            "recoilPitchMin", "recoilPitchMax"
+        };
+
+        private void Update()
+        {
+            if (!SettingsInstance.GetBoolValue(nameof(SettingsBools.NO_RECOIL)))
+                return;
+
+            if (Player == null)
+                return;
+
+            var inv = Player.inventory;
+            if (inv == null)
+                return;
+
+            var gun = inv.GetHoldingGun();
+            if (gun == null)
+                return;
+
+            var type = gun.GetType();
+            foreach (var name in fieldNames)
+            {
+                var field = type.GetField(name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                if (field != null && field.FieldType == typeof(float))
+                {
+                    field.SetValue(gun, 0f);
+                }
+            }
+        }
+    }
+}

--- a/7d2dMonoInternal/Loader.cs
+++ b/7d2dMonoInternal/Loader.cs
@@ -39,6 +39,7 @@ namespace SevenDTDMono
             gameObject.AddComponent<Features.Render.Visuals>();
             gameObject.AddComponent<Features.Aimbot>();
             gameObject.AddComponent<Features.Magic.MagicBullet>();
+            gameObject.AddComponent<Features.Weapon.NoRecoil>();
 
             //gameObject.AddComponent<SceneDebugger>();
             //gameObject.AddComponent<CBuffs>();

--- a/7d2dMonoInternal/Misc/EnumNonDynamicLoadBools.cs
+++ b/7d2dMonoInternal/Misc/EnumNonDynamicLoadBools.cs
@@ -21,6 +21,7 @@ namespace SevenDTDMono
         FOV_CIRCLE,
         CROSS_HAIR,
         NO_WEAPON_BOB,
+        NO_RECOIL,
         CHAMS,
         CHEAT_BUFF,
         CHEAT_BUFFS_LOADED,

--- a/7d2dMonoInternal/README.md
+++ b/7d2dMonoInternal/README.md
@@ -16,26 +16,26 @@ F7 default for UnityExplorer. rekomended to set to other button since 7dtd use f
 2. Health ESP, Corner Box ESP, Name ESP, Box ESP, Chams (players & zombies)
 3. FOV Aimbot with adjustable angle (players & zombies)
 4. No weapon sway, high viewmodel FOV
-5. Infinite ammo
-6. Toggle creative mode and debug mode +
-7. Crosshair, toggleable FOV circle
-8. Speedhack
-9. Teleport to players / zombies Also Kill Players /Zombies
-10. Level up
-11. Add 10 skill points
-12. Health and stamina  // you can still take damage! this only makes regen as same phase as loss
-13. food and water //this only makes regen as same phase as loss
-14.BUFFS
+5. No recoil (works with aimbot)
+6. Infinite ammo
+7. Toggle creative mode and debug mode +
+8. Crosshair, toggleable FOV circle
+9. Speedhack
+10. Teleport to players / zombies Also Kill Players /Zombies
+11. Level up
+12. Add 10 skill points
+13. Health and stamina  // you can still take damage! this only makes regen as same phase as loss
+14. food and water //this only makes regen as same phase as loss
+15.BUFFS
     14.1  Buffs trigger //just press button in buffs scroll view to apply buff to yourself
     14.2 Remove all buffs
     14.3 Add good Buffs
     14.4 Add out custom cheatbuff shich work together with Passive effect add //
     14.5 Clear cheatbuff incase we mess upp
     14.6 add effect group should not need to be used, but incase you dont get effects by addding passive effect use this button
-    14.7 some more buttosn setting passives  
+    14.7 some more buttosn setting passives
 16. Ignored på AI
 17. SceneDebugger (F3)
-18. 
 
 I added some log output, Primary for debugging but could be usefull in other cases
 ![log_](https://github.com/mcpolo99/7d2dMonoInternal/assets/32239939/90c01af9-dbf6-44df-9a82-e5df20f1be37)

--- a/7d2dMonoInternal/SevenDTDMono.csproj
+++ b/7d2dMonoInternal/SevenDTDMono.csproj
@@ -323,6 +323,7 @@
     <Compile Include="Features\Render\ESP.cs" />
     <Compile Include="Features\Render\Visuals.cs" />
     <Compile Include="Features\Render\Render.cs" />
+    <Compile Include="Features\Weapon\NoRecoil.cs" />
     <None Include="Directory.Build.props" />
     <None Include="FileName.cs" />
     <Compile Include="GuiLayoutExtended\GUIFoldableMenu.cs" />

--- a/7d2dMonoInternal/UI/NewMenu.cs
+++ b/7d2dMonoInternal/UI/NewMenu.cs
@@ -469,6 +469,7 @@ namespace SevenDTDMono
                     NewGUILayout.DropDownForMethods("Aimbot Settings", () =>
                     {
                         NewGUILayout.ButtonToggleDictionary("Magic Bullet", nameof(SettingsBools.MAGIC_BULLET));
+                        NewGUILayout.ButtonToggleDictionary("No Recoil", nameof(SettingsBools.NO_RECOIL));
                         string[] targets = System.Enum.GetNames(typeof(AimbotTarget));
                         int selected = (int)SettingsInstance.SelectedAimbotTarget;
                         int newSelected = GUILayout.Toolbar(selected, targets);


### PR DESCRIPTION
## Summary
- add a new `NO_RECOIL` setting
- implement `NoRecoil` component that zeroes recoil fields on the current gun
- toggle the feature from AIM tab
- load component in Loader
- document new option in README

## Testing
- `dotnet build 7DTD-Main.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878c2cb08f48330922c94cf237a6841