### PR TITLE
Move no recoil out of aimbot dropdown

### DIFF
--- a/7d2dMonoInternal/UI/NewMenu.cs
+++ b/7d2dMonoInternal/UI/NewMenu.cs
@@ -464,12 +464,13 @@ namespace SevenDTDMono
             {
                 NewGUILayout.ButtonToggleDictionary("Aimbot", nameof(SettingsBools.AIMBOT));
 
+                NewGUILayout.ButtonToggleDictionary("No Recoil", nameof(SettingsBools.NO_RECOIL));
+
                 if (_boolDict[nameof(SettingsBools.AIMBOT)])
                 {
                     NewGUILayout.DropDownForMethods("Aimbot Settings", () =>
                     {
                         NewGUILayout.ButtonToggleDictionary("Magic Bullet", nameof(SettingsBools.MAGIC_BULLET));
-                        NewGUILayout.ButtonToggleDictionary("No Recoil", nameof(SettingsBools.NO_RECOIL));
                         string[] targets = System.Enum.GetNames(typeof(AimbotTarget));
                         int selected = (int)SettingsInstance.SelectedAimbotTarget;
                         int newSelected = GUILayout.Toolbar(selected, targets);


### PR DESCRIPTION
## Summary
- keep no recoil toggle but move it out of the aimbot dropdown so it appears directly on the AIM tab

## Testing
- `dotnet build 7DTD-Main.sln` *(fails: reference assemblies for .NET Framework 4.8 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6878c5cacc6c83308d485846b0f59408