### PR TITLE
Add bullet path option

### DIFF
--- a/7d2dMonoInternal/Features/Aimbot/Aimbot.cs
+++ b/7d2dMonoInternal/Features/Aimbot/Aimbot.cs
@@ -10,6 +10,11 @@ namespace SevenDTDMono.Features
         private static Dictionary<string, bool> BoolDict => SettingsInstance.GetChildDictionary<bool>(nameof(Dictionaries.BOOL_DICTIONARY));
         private static EntityPlayerLocal Player => NewSettings.EntityLocalPlayer;
 
+        // Expose the latest calculated path for debug drawing
+        public static bool HasTarget { get; private set; }
+        public static Vector3 StartPos { get; private set; }
+        public static Vector3 TargetPos { get; private set; }
+
         // Hold this key for the aimbot to activate
         private readonly KeyCode activationKey = KeyCode.LeftAlt;
 
@@ -35,6 +40,7 @@ namespace SevenDTDMono.Features
                 return;
             }
 
+            HasTarget = false;
             EntityAlive bestZombie = null;
             float minAngle = float.MaxValue;
 
@@ -91,6 +97,11 @@ namespace SevenDTDMono.Features
                 {
                     Camera.main.transform.rotation = Player.transform.rotation;
                 }
+
+                // Store positions for debug drawing
+                StartPos = referencePos;
+                TargetPos = targetPos;
+                HasTarget = true;
             }
         }
 

--- a/7d2dMonoInternal/Features/Render/Render.cs
+++ b/7d2dMonoInternal/Features/Render/Render.cs
@@ -1,6 +1,7 @@
 ﻿using UnityEngine;
 
 using System.Collections.Generic;
+using SevenDTDMono.Features;
 
 namespace SevenDTDMono.Features.Render
 {
@@ -84,6 +85,18 @@ namespace SevenDTDMono.Features.Render
                 RenderUtils.DrawCircle(Color.black, new Vector2(Screen.width / 2, Screen.height / 2), radius - 1f);
                 RenderUtils.DrawCircle(Color.black, new Vector2(Screen.width / 2, Screen.height / 2), radius + 1f);
                 RenderUtils.DrawCircle(new Color32(30, 144, 255, 255), new Vector2(Screen.width / 2, Screen.height / 2), radius);
+            }
+
+            if (SettingsInstance.GetBoolValue(nameof(SettingsBools.BULLET_PATH)) && Aimbot.HasTarget && Camera.main)
+            {
+                Vector3 startScreen = Camera.main.WorldToScreenPoint(Aimbot.StartPos);
+                Vector3 endScreen = Camera.main.WorldToScreenPoint(Aimbot.TargetPos);
+                if (RenderUtils.IsOnScreen(startScreen) && RenderUtils.IsOnScreen(endScreen))
+                {
+                    Vector2 start = new Vector2(startScreen.x, Screen.height - startScreen.y);
+                    Vector2 end = new Vector2(endScreen.x, Screen.height - endScreen.y);
+                    RenderUtils.DrawLine(start, end, Color.red, 2f);
+                }
             }
 
 

--- a/7d2dMonoInternal/Misc/EnumNonDynamicLoadBools.cs
+++ b/7d2dMonoInternal/Misc/EnumNonDynamicLoadBools.cs
@@ -29,6 +29,7 @@ namespace SevenDTDMono
         PROGRESSION_VALUE_LOADED,
         NAME_SCRAMBLE,
         AIMBOT,
-        MAGIC_BULLET
+        MAGIC_BULLET,
+        BULLET_PATH
     }
 }

--- a/7d2dMonoInternal/README.md
+++ b/7d2dMonoInternal/README.md
@@ -20,13 +20,14 @@ F7 default for UnityExplorer. rekomended to set to other button since 7dtd use f
 6. Infinite ammo
 7. Toggle creative mode and debug mode +
 8. Crosshair, toggleable FOV circle
-9. Speedhack
-10. Teleport to players / zombies Also Kill Players /Zombies
-11. Level up
-12. Add 10 skill points
-13. Health and stamina  // you can still take damage! this only makes regen as same phase as loss
-14. food and water //this only makes regen as same phase as loss
-15.BUFFS
+9. Bullet path debug line for aimbot
+10. Speedhack
+11. Teleport to players / zombies Also Kill Players /Zombies
+12. Level up
+13. Add 10 skill points
+14. Health and stamina  // you can still take damage! this only makes regen as same phase as loss
+15. food and water //this only makes regen as same phase as loss
+16.BUFFS
     14.1  Buffs trigger //just press button in buffs scroll view to apply buff to yourself
     14.2 Remove all buffs
     14.3 Add good Buffs
@@ -34,8 +35,8 @@ F7 default for UnityExplorer. rekomended to set to other button since 7dtd use f
     14.5 Clear cheatbuff incase we mess upp
     14.6 add effect group should not need to be used, but incase you dont get effects by addding passive effect use this button
     14.7 some more buttosn setting passives
-16. Ignored på AI
-17. SceneDebugger (F3)
+17. Ignored på AI
+18. SceneDebugger (F3)
 
 I added some log output, Primary for debugging but could be usefull in other cases
 ![log_](https://github.com/mcpolo99/7d2dMonoInternal/assets/32239939/90c01af9-dbf6-44df-9a82-e5df20f1be37)

--- a/7d2dMonoInternal/UI/NewMenu.cs
+++ b/7d2dMonoInternal/UI/NewMenu.cs
@@ -471,6 +471,7 @@ namespace SevenDTDMono
                     NewGUILayout.DropDownForMethods("Aimbot Settings", () =>
                     {
                         NewGUILayout.ButtonToggleDictionary("Magic Bullet", nameof(SettingsBools.MAGIC_BULLET));
+                        NewGUILayout.ButtonToggleDictionary("Bullet Path", nameof(SettingsBools.BULLET_PATH));
                         string[] targets = System.Enum.GetNames(typeof(AimbotTarget));
                         int selected = (int)SettingsInstance.SelectedAimbotTarget;
                         int newSelected = GUILayout.Toolbar(selected, targets);


### PR DESCRIPTION
## Summary
- add `BULLET_PATH` toggle in settings
- expose last aimbot target for drawing
- render bullet trajectory if enabled
- document bullet path debug line

## Testing
- `dotnet build 7DTD-Main.sln -c Release` *(fails: reference assemblies for .NETFramework 4.8 not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878cbfbd8e88330ab8c6d1ddeeb1dba