### PR TITLE
Add Show Fov overlay

### DIFF
--- a/7d2dMonoInternal/Features/Render/Render.cs
+++ b/7d2dMonoInternal/Features/Render/Render.cs
@@ -130,6 +130,19 @@ namespace SevenDTDMono.Features.Render
                 RenderUtils.DrawCircle(new Color32(30, 144, 255, 255), new Vector2(Screen.width / 2, Screen.height / 2), radius);
             }
 
+            if (SettingsInstance.GetBoolValue(nameof(SettingsBools.SHOW_FOV)))
+            {
+                float radius = 150f;
+                if (Camera.main)
+                {
+                    float angleRatio = Mathf.Tan(SettingsInstance.AimbotFov * Mathf.Deg2Rad * 0.5f) /
+                                       Mathf.Tan(Camera.main.fieldOfView * Mathf.Deg2Rad * 0.5f);
+                    radius = (Screen.height / 2f) * angleRatio;
+                }
+
+                RenderUtils.DrawCircle(Color.red, new Vector2(Screen.width / 2, Screen.height / 2), radius);
+            }
+
             if (SettingsInstance.GetBoolValue(nameof(SettingsBools.BULLET_PATH)) && Aimbot.HasTarget && Camera.main)
             {
                 Vector3 startScreen = Camera.main.WorldToScreenPoint(Aimbot.StartPos);

--- a/7d2dMonoInternal/Misc/EnumNonDynamicLoadBools.cs
+++ b/7d2dMonoInternal/Misc/EnumNonDynamicLoadBools.cs
@@ -19,6 +19,7 @@ namespace SevenDTDMono
         ZOMBIE_CORNER_BOX,
         ZOMBIE_BOX,
         FOV_CIRCLE,
+        SHOW_FOV,
         CROSS_HAIR,
         NO_WEAPON_BOB,
         NO_RECOIL,

--- a/7d2dMonoInternal/README.md
+++ b/7d2dMonoInternal/README.md
@@ -20,9 +20,10 @@ F7 default for UnityExplorer. rekomended to set to other button since 7dtd use f
 6. Infinite ammo
 7. Toggle creative mode and debug mode +
 8. Crosshair, toggleable FOV circle
-9. Bullet path debug line for aimbot
-10. Speedhack
-11. Teleport to players / zombies Also Kill Players /Zombies
+9. Show Fov overlay to visualize aimbot FOV
+10. Bullet path debug line for aimbot
+11. Speedhack
+12. Teleport to players / zombies Also Kill Players /Zombies
 12. Level up
 13. Add 10 skill points
 14. Health and stamina  // you can still take damage! this only makes regen as same phase as loss

--- a/7d2dMonoInternal/UI/NewMenu.cs
+++ b/7d2dMonoInternal/UI/NewMenu.cs
@@ -485,6 +485,8 @@ namespace SevenDTDMono
                         SettingsInstance.AimbotFov = GUILayout.HorizontalSlider(SettingsInstance.AimbotFov, 10f, 120f, GUILayout.Width(150));
                         GUILayout.EndHorizontal();
 
+                        NewGUILayout.ButtonToggleDictionary("Show Fov", nameof(SettingsBools.SHOW_FOV));
+
                     }, ref aimbotSettingsDropdown);
                 }
             });


### PR DESCRIPTION
## Summary
- add a new `SHOW_FOV` option
- render a red circle representing the current aimbot FOV
- expose the toggle in the menu
- document the feature in README

## Testing
- `dotnet build 7DTD-Main.sln -c Release` *(fails: reference assemblies for .NETFramework 4.8 not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878fb9a6a408330b1f81f9a5fd5c6b2