### PR TITLE
Implement target indicator for aimbot

### DIFF
--- a/7d2dMonoInternal/Features/Render/Render.cs
+++ b/7d2dMonoInternal/Features/Render/Render.cs
@@ -143,6 +143,18 @@ namespace SevenDTDMono.Features.Render
                 RenderUtils.DrawCircle(Color.red, new Vector2(Screen.width / 2, Screen.height / 2), radius);
             }
 
+            if (SettingsInstance.GetBoolValue(nameof(SettingsBools.SHOW_TARGET)) &&
+                Aimbot.HasTarget && Input.GetKey(KeyCode.LeftAlt) && Camera.main)
+            {
+                Vector3 targetScreen = Camera.main.WorldToScreenPoint(Aimbot.TargetPos);
+                if (RenderUtils.IsOnScreen(targetScreen))
+                {
+                    Vector2 pos = new Vector2(targetScreen.x, Screen.height - targetScreen.y);
+                    RenderUtils.DrawCircle(Color.black, pos, 6f);
+                    RenderUtils.DrawCircle(Color.green, pos, 5f);
+                }
+            }
+
             if (SettingsInstance.GetBoolValue(nameof(SettingsBools.BULLET_PATH)) && Aimbot.HasTarget && Camera.main)
             {
                 Vector3 startScreen = Camera.main.WorldToScreenPoint(Aimbot.StartPos);

--- a/7d2dMonoInternal/Misc/EnumNonDynamicLoadBools.cs
+++ b/7d2dMonoInternal/Misc/EnumNonDynamicLoadBools.cs
@@ -31,6 +31,7 @@ namespace SevenDTDMono
         NAME_SCRAMBLE,
         AIMBOT,
         MAGIC_BULLET,
-        BULLET_PATH
+        BULLET_PATH,
+        SHOW_TARGET
     }
 }

--- a/7d2dMonoInternal/UI/NewMenu.cs
+++ b/7d2dMonoInternal/UI/NewMenu.cs
@@ -472,6 +472,7 @@ namespace SevenDTDMono
                     {
                         NewGUILayout.ButtonToggleDictionary("Magic Bullet", nameof(SettingsBools.MAGIC_BULLET));
                         NewGUILayout.ButtonToggleDictionary("Bullet Path", nameof(SettingsBools.BULLET_PATH));
+                        NewGUILayout.ButtonToggleDictionary("Show Target", nameof(SettingsBools.SHOW_TARGET));
                         string[] targets = System.Enum.GetNames(typeof(AimbotTarget));
                         int selected = (int)SettingsInstance.SelectedAimbotTarget;
                         int newSelected = GUILayout.Toolbar(selected, targets);


### PR DESCRIPTION
## Summary
- add `SHOW_TARGET` toggle to settings
- allow enabling `Show Target` from menu
- visualize aimbot target position when holding Left Alt

## Testing
- `dotnet build 7DTD-Main.sln` *(fails: reference assemblies for .NETFramework v4.8 missing)*

------
https://chatgpt.com/codex/tasks/task_e_687901280b348330824993dbe6e5e88d