### PR TITLE
Add movement prediction option

### DIFF
--- a/7d2dMonoInternal/Features/Aimbot/Aimbot.cs
+++ b/7d2dMonoInternal/Features/Aimbot/Aimbot.cs
@@ -147,6 +147,13 @@ namespace SevenDTDMono.Features
         private Vector3 PredictEntityBasePosition(EntityAlive entity)
         {
             Vector3 current = entity.transform.position;
+
+            // Early out if movement prediction is disabled
+            if (!SettingsInstance.GetBoolValue(nameof(SettingsBools.MOVEMENT_PREDICTION)))
+            {
+                return current;
+            }
+
             if (previousPositions.TryGetValue(entity.entityId, out Vector3 last))
             {
                 float dt = Time.deltaTime;

--- a/7d2dMonoInternal/Misc/EnumNonDynamicLoadBools.cs
+++ b/7d2dMonoInternal/Misc/EnumNonDynamicLoadBools.cs
@@ -32,6 +32,7 @@ namespace SevenDTDMono
         AIMBOT,
         MAGIC_BULLET,
         BULLET_PATH,
-        SHOW_TARGET
+        SHOW_TARGET,
+        MOVEMENT_PREDICTION
     }
 }

--- a/7d2dMonoInternal/UI/NewMenu.cs
+++ b/7d2dMonoInternal/UI/NewMenu.cs
@@ -473,6 +473,7 @@ namespace SevenDTDMono
                         NewGUILayout.ButtonToggleDictionary("Magic Bullet", nameof(SettingsBools.MAGIC_BULLET));
                         NewGUILayout.ButtonToggleDictionary("Bullet Path", nameof(SettingsBools.BULLET_PATH));
                         NewGUILayout.ButtonToggleDictionary("Show Target", nameof(SettingsBools.SHOW_TARGET));
+                        NewGUILayout.ButtonToggleDictionary("Movement Prediction", nameof(SettingsBools.MOVEMENT_PREDICTION));
                         string[] targets = System.Enum.GetNames(typeof(AimbotTarget));
                         int selected = (int)SettingsInstance.SelectedAimbotTarget;
                         int newSelected = GUILayout.Toolbar(selected, targets);


### PR DESCRIPTION
## Summary
- add `MOVEMENT_PREDICTION` setting
- conditionally predict target movement in aimbot
- expose new toggle in the menu

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68790b3b96a48330bd9ed2b82614dba1