### PR TITLE
Add bullet drop compensation

### DIFF
--- a/7d2dMonoInternal/Features/Aimbot/Aimbot.cs
+++ b/7d2dMonoInternal/Features/Aimbot/Aimbot.cs
@@ -176,25 +176,43 @@ namespace SevenDTDMono.Features
         {
             float height = GetEntityHeight(entity);
             Vector3 basePos = PredictEntityBasePosition(entity);
+            Vector3 target;
 
             switch (SettingsInstance.SelectedAimbotTarget)
             {
                 case AimbotTarget.Chest:
-                    return basePos + Vector3.up * height * 0.5f;
+                    target = basePos + Vector3.up * height * 0.5f;
+                    break;
                 case AimbotTarget.Feet:
-                    return basePos + Vector3.up * height * 0.1f;
+                    target = basePos + Vector3.up * height * 0.1f;
+                    break;
                 default:
                     Transform head = entity.emodel?.GetHeadTransform();
                     if (head != null)
                     {
                         Vector3 offset = head.position - entity.transform.position;
-                        return basePos + offset;
+                        target = basePos + offset;
                     }
                     else
                     {
-                        return basePos + Vector3.up * height * 0.9f;
+                        target = basePos + Vector3.up * height * 0.9f;
                     }
+                    break;
             }
+
+            // Compensate for bullet drop by aiming slightly above the target
+            if (Camera.main)
+            {
+                Vector3 from = Camera.main.transform.position;
+                float distance = Vector3.Distance(from, target);
+                // Simple ballistic drop approximation
+                float gravity = 9.81f;
+                float travelTime = distance / projectileSpeed;
+                float drop = 0.5f * gravity * travelTime * travelTime;
+                target += Vector3.up * drop;
+            }
+
+            return target;
         }
 
         /// <summary>

--- a/7d2dMonoInternal/README.md
+++ b/7d2dMonoInternal/README.md
@@ -22,13 +22,14 @@ F7 default for UnityExplorer. rekomended to set to other button since 7dtd use f
 8. Crosshair, toggleable FOV circle
 9. Show Fov overlay to visualize aimbot FOV
 10. Bullet path debug line for aimbot
-11. Speedhack
-12. Teleport to players / zombies Also Kill Players /Zombies
-12. Level up
-13. Add 10 skill points
-14. Health and stamina  // you can still take damage! this only makes regen as same phase as loss
-15. food and water //this only makes regen as same phase as loss
-16.BUFFS
+11. Bullet drop compensation for aimbot
+12. Speedhack
+13. Teleport to players / zombies Also Kill Players /Zombies
+14. Level up
+15. Add 10 skill points
+16. Health and stamina  // you can still take damage! this only makes regen as same phase as loss
+17. food and water //this only makes regen as same phase as loss
+18. BUFFS
     14.1  Buffs trigger //just press button in buffs scroll view to apply buff to yourself
     14.2 Remove all buffs
     14.3 Add good Buffs
@@ -36,8 +37,8 @@ F7 default for UnityExplorer. rekomended to set to other button since 7dtd use f
     14.5 Clear cheatbuff incase we mess upp
     14.6 add effect group should not need to be used, but incase you dont get effects by addding passive effect use this button
     14.7 some more buttosn setting passives
-17. Ignored på AI
-18. SceneDebugger (F3)
+19. Ignored på AI
+20. SceneDebugger (F3)
 
 I added some log output, Primary for debugging but could be usefull in other cases
 ![log_](https://github.com/mcpolo99/7d2dMonoInternal/assets/32239939/90c01af9-dbf6-44df-9a82-e5df20f1be37)


### PR DESCRIPTION
## Summary
- aimbot now accounts for projectile drop when aiming
- document new bullet drop compensation feature

## Testing
- `dotnet build 7DTD-Main.sln` *(fails: reference assemblies for .NETFramework v4.8 not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879144c364c8330b5940d5f7eb680f7