### PR TITLE
Fix bullet drop while movement prediction disabled

### DIFF
--- a/7d2dMonoInternal/Features/Aimbot/Aimbot.cs
+++ b/7d2dMonoInternal/Features/Aimbot/Aimbot.cs
@@ -223,7 +223,10 @@ namespace SevenDTDMono.Features
             }
 
             // Compensate for bullet drop by aiming slightly above the target
-            if (Camera.main)
+            // Only apply when movement prediction is enabled so disabling the
+            // feature results in fully "raw" aiming.
+            if (Camera.main &&
+                SettingsInstance.GetBoolValue(nameof(SettingsBools.MOVEMENT_PREDICTION)))
             {
                 Vector3 from = Camera.main.transform.position;
                 float distance = Vector3.Distance(from, target);


### PR DESCRIPTION
## Summary
- tie bullet drop compensation to the Movement Prediction setting so it isn't applied when that feature is disabled

## Testing
- `dotnet build 7DTD-Main.sln -c Release` *(fails: reference assemblies for .NETFramework,Version=v4.8 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_687928b0c43483308019eaabe9e42ec8