### PR TITLE
Add silent aim setting

### DIFF
--- a/7d2dMonoInternal/Features/Aimbot/Aimbot.cs
+++ b/7d2dMonoInternal/Features/Aimbot/Aimbot.cs
@@ -111,19 +111,27 @@ namespace SevenDTDMono.Features
                 Vector3 direction = targetPos - referencePos;
                 Quaternion look = Quaternion.LookRotation(direction);
 
-                // Smoothly rotate the player towards the target. Directly
-                // setting the rotation each frame caused visible jitter while
-                // moving. Using Slerp keeps the motion fluid.
-                Player.transform.rotation = Quaternion.Slerp(
-                    Player.transform.rotation,
-                    look,
-                    rotationSpeed * Time.deltaTime);
-
-                // Keep the camera aligned with the player so the crosshair
-                // matches the adjusted view direction.
-                if (Camera.main)
+                if (SettingsInstance.SelectedAimbotMode == AimbotMode.Normal)
                 {
-                    Camera.main.transform.rotation = Player.transform.rotation;
+                    // Smoothly rotate the player towards the target. Directly
+                    // setting the rotation each frame caused visible jitter while
+                    // moving. Using Slerp keeps the motion fluid.
+                    Player.transform.rotation = Quaternion.Slerp(
+                        Player.transform.rotation,
+                        look,
+                        rotationSpeed * Time.deltaTime);
+
+                    // Keep the camera aligned with the player so the crosshair
+                    // matches the adjusted view direction.
+                    if (Camera.main)
+                    {
+                        Camera.main.transform.rotation = Player.transform.rotation;
+                    }
+                }
+                else if (SettingsInstance.SelectedAimbotMode == AimbotMode.Silent && Input.GetMouseButtonDown(0))
+                {
+                    // Directly damage the target when firing without adjusting the view
+                    bestZombie.DamageEntity(new DamageSource(EnumDamageSource.Internal, EnumDamageTypes.Suicide), 99999, false, 1f);
                 }
 
                 // Store positions for debug drawing

--- a/7d2dMonoInternal/Misc/EnumAimbotMode.cs
+++ b/7d2dMonoInternal/Misc/EnumAimbotMode.cs
@@ -1,0 +1,8 @@
+namespace SevenDTDMono
+{
+    public enum AimbotMode
+    {
+        Normal,
+        Silent
+    }
+}

--- a/7d2dMonoInternal/NewSettings.cs
+++ b/7d2dMonoInternal/NewSettings.cs
@@ -49,6 +49,9 @@ namespace SevenDTDMono
         // Selected target area for the aimbot feature
         public AimbotTarget SelectedAimbotTarget = AimbotTarget.Head;
 
+        // Choose between normal aimbot or silent aim
+        public AimbotMode SelectedAimbotMode = AimbotMode.Normal;
+
         // Field of view in degrees used by the aimbot
         public float AimbotFov = 60f;
 

--- a/7d2dMonoInternal/SevenDTDMono.csproj
+++ b/7d2dMonoInternal/SevenDTDMono.csproj
@@ -338,6 +338,7 @@
     <Compile Include="Misc\EnumChildDictionaries.cs" />
     <Compile Include="Misc\EnumNonDynamicLoadBools.cs" />
     <Compile Include="Misc\EnumAimbotTarget.cs" />
+    <Compile Include="Misc\EnumAimbotMode.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Utils\AssemblyHelper.cs" />
     <Compile Include="GuiLayoutExtended\GUILayoutExtensions.cs" />

--- a/7d2dMonoInternal/UI/NewMenu.cs
+++ b/7d2dMonoInternal/UI/NewMenu.cs
@@ -489,6 +489,14 @@ namespace SevenDTDMono
 
                         NewGUILayout.ButtonToggleDictionary("Show Fov", nameof(SettingsBools.SHOW_FOV));
 
+                        string[] modes = System.Enum.GetNames(typeof(AimbotMode));
+                        int modeSelected = (int)SettingsInstance.SelectedAimbotMode;
+                        int newMode = GUILayout.Toolbar(modeSelected, modes);
+                        if (newMode != modeSelected)
+                        {
+                            SettingsInstance.SelectedAimbotMode = (AimbotMode)newMode;
+                        }
+
                     }, ref aimbotSettingsDropdown);
                 }
             });


### PR DESCRIPTION
## Summary
- add `EnumAimbotMode` with Normal and Silent
- allow selecting aimbot mode in settings UI
- store selected aimbot mode in settings
- update Aimbot to optionally perform silent aim
- include new enum in project file

## Testing
- `dotnet build 7d2dMonoInternal/SevenDTDMono.csproj -c Release` *(fails: reference assemblies for .NETFramework v4.8 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68794063c1048330ab15b9867a7afc90