### PR TITLE
Check line of sight when locking aimbot target

### DIFF
--- a/7d2dMonoInternal/Features/Aimbot/Aimbot.cs
+++ b/7d2dMonoInternal/Features/Aimbot/Aimbot.cs
@@ -85,7 +85,17 @@ namespace SevenDTDMono.Features
 
             if (lockedZombie != null && lockedZombie.IsAlive())
             {
-                bestZombie = lockedZombie;
+                // Verify the locked target still meets FOV and line of sight requirements
+                Vector3 lockedTarget = GetTargetPositionSimple(lockedZombie);
+                if (IsWithinFov(lockedTarget) &&
+                    HasLineOfSight(referencePos, lockedTarget, lockedZombie))
+                {
+                    bestZombie = lockedZombie;
+                }
+                else
+                {
+                    lockedZombie = null;
+                }
             }
             else
             {


### PR DESCRIPTION
## Summary
- verify FOV and line-of-sight for the currently locked zombie each frame
- unlock the target if it's behind cover or outside FOV

## Testing
- `dotnet build 7DTD-Main.sln -c Release` *(fails: reference assemblies for .NETFramework,Version=v4.8 not found)*
- `xbuild 7DTD-Main.sln /p:Configuration=Release` *(fails: OutputPath property is not set)*

------
https://chatgpt.com/codex/tasks/task_e_6879483c98208330abd891cd68817793